### PR TITLE
Bugfix/33: Fix to only return keywords belong to users

### DIFF
--- a/apps/api/src/routes/keywords/handler.ts
+++ b/apps/api/src/routes/keywords/handler.ts
@@ -6,20 +6,22 @@ const router = Router();
 
 router.get("", async (req, res, next) => {
   const uploadId = (req.query.uploadId as string) || null;
+  const userId = req.user?.userId || "";
 
   try {
-    const rawKeywords = await keywordRepository.getAll(uploadId);
+    const keywords = await keywordRepository.getAll(uploadId, userId);
 
-    const keywords = rawKeywords.map((raw) => {
+    // convert bigint value to int before the keywords can be serializing in JSON
+    const convertedKeywords = keywords.map((keyword) => {
       return {
-        ...raw,
-        resultCount: Number(raw.resultCount),
+        ...keyword,
+        resultCount: Number(keyword.resultCount),
       };
     });
 
     res.json({
       ok: true,
-      keywords,
+      keywords: convertedKeywords,
     });
   } catch (error) {
     console.error(error);
@@ -29,26 +31,26 @@ router.get("", async (req, res, next) => {
 
 router.get("/:keywordId", async (req, res, next) => {
   try {
-    const rawKeyword = await keywordRepository.getOne(req.params.keywordId);
+    const keyword = await keywordRepository.getOne(req.params.keywordId);
 
-    if (!rawKeyword) {
+    if (!keyword) {
       res.json({
         ok: true,
-        message: "keyword not found",
+        message: "not found",
       });
 
       return;
     }
 
-    const keyword = {
-      ...rawKeyword,
-      resultCount: Number(rawKeyword.resultCount),
-      rawHtmlResult: rawKeyword.rawHtmlResult.toString(),
+    const keywordConverted = {
+      ...keyword,
+      resultCount: Number(keyword.resultCount),
+      rawHtmlResult: keyword.rawHtmlResult.toString(),
     };
 
     res.json({
       ok: true,
-      keyword,
+      keyword: keywordConverted,
     });
   } catch (error) {
     console.log(error);

--- a/apps/api/src/routes/keywords/keyword.repository.ts
+++ b/apps/api/src/routes/keywords/keyword.repository.ts
@@ -1,23 +1,26 @@
 import { DatabaseClient } from "../../infra";
 
-export async function getAll(uploadId: string | null) {
-  if (!uploadId) {
+export async function getAll(uploadId: string | null, userId: string) {
+  if (uploadId) {
     return DatabaseClient.keyword.findMany({
-      select: {
-        resultCount: true,
-        createdAt: true,
-        keywordId: true,
-        linkCount: true,
-        adWordsCount: true,
-        uploadId: true,
-        body: true,
+      where: {
+        uploadId,
+        upload: {
+          userId,
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
       },
     });
   }
 
+  // no uploadId, return all that belong to user
   return DatabaseClient.keyword.findMany({
     where: {
-      uploadId,
+      upload: {
+        userId,
+      },
     },
     select: {
       resultCount: true,
@@ -27,6 +30,9 @@ export async function getAll(uploadId: string | null) {
       adWordsCount: true,
       uploadId: true,
       body: true,
+    },
+    orderBy: {
+      createdAt: "desc",
     },
   });
 }

--- a/apps/api/src/routes/uploads/upload.processor.ts
+++ b/apps/api/src/routes/uploads/upload.processor.ts
@@ -1,12 +1,11 @@
 import * as cheerio from "cheerio";
 import UserAgent from "user-agents";
+import axios from "axios";
 
 import {
   type ProcessedKeywordResult,
   type RawKeywordResult,
 } from "../../types";
-import axios from "axios";
-import { HttpsProxyAgent } from "https-proxy-agent";
 
 type KeywordWithUserAgent = {
   keyword: string;
@@ -43,11 +42,8 @@ export async function scrape(
 
       const option = {
         headers,
-        proxy: false,
-        httpsAgent: new HttpsProxyAgent("http://15.204.161.192:18080"),
       };
 
-      console.info({ keywordUrl, userAgent });
       // @ts-ignore
       return axios.get(keywordUrl, option);
     })

--- a/apps/api/src/routes/uploads/upload.repository.ts
+++ b/apps/api/src/routes/uploads/upload.repository.ts
@@ -23,5 +23,8 @@ export async function getAll(userId: string) {
     where: {
       userId,
     },
+    orderBy: {
+      createdAt: "desc",
+    },
   });
 }

--- a/sample.csv
+++ b/sample.csv
@@ -1,1 +1,5 @@
 macbook pro m2
+airpods pro
+macbook air 2022
+samsung galaxy s23
+apple vision pro


### PR DESCRIPTION
#### What does this PR do?

This PR is to fix issue #33
Close #33 

#### How is it implemented?

Update the query in the `keyword` repository to include the user ID so that only keywords belonging to the user are returned 