### PR TITLE
Bugfix/40: Fix `keywords` page is loading slow

### DIFF
--- a/apps/api/src/routes/keywords/repositories/keyword.repository.ts
+++ b/apps/api/src/routes/keywords/repositories/keyword.repository.ts
@@ -9,6 +9,16 @@ export async function getAll(uploadId: string | null, userId: string) {
           userId,
         },
       },
+      select: {
+        resultCount: true,
+        createdAt: true,
+        keywordId: true,
+        linkCount: true,
+        adWordsCount: true,
+        uploadId: true,
+        body: true,
+        rawHtmlResult: false,
+      },
       orderBy: {
         createdAt: "desc",
       },
@@ -30,6 +40,7 @@ export async function getAll(uploadId: string | null, userId: string) {
       adWordsCount: true,
       uploadId: true,
       body: true,
+      rawHtmlResult: false,
     },
     orderBy: {
       createdAt: "desc",


### PR DESCRIPTION
#### What does this PR do?

This PR is to fix the `keywords` page being loaded very slow
Close #40 

#### How is it fixed?

Re-add the `select` scheme that exclusively excludes the page HTML of each keyword in response payload of the `GET /keywords` endpoint

Related PR: https://github.com/nhantran3395/scrapper/pull/26