### PR TITLE
Bugfix/29: Add missing validation for the number of keywords in a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ NEXT_PUBLIC_BASE_API_URL="http://localhost:5001"
 ```bash
 DATABASE_URL="postgres://user:password@host/dbname"
 CORS_WHITELIST="http://localhost:3002"
+FILE_UPLOAD_MAX_KEYWORD_LIMIT=100
+FILE_UPLOAD_MAX_SIZE=1024 #in bytes
 ```
 
 Note: 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To run the application from your local, follow the below steps:
 
 2. Prepare the environment variables
 
-- For the Web, place the following content in the `.env` file in `apps/web` folder
+- For the Web, place the following content in the `.env.local` file in `apps/web` folder
 ```bash
 NEXT_PUBLIC_BASE_API_URL="http://localhost:5001"
 ```
@@ -74,10 +74,12 @@ npm run dev
 
 The following techniques have been considered to avoid Google from blocking the request:
 
-- Randomizing user agents: Apply a random user agent to each request
-- Rotating proxy: Use a pool of proxy that can be rotated. If a scrape request fail, the same request can be retried with proxies from the pool. 
+- **Randomizing user agents**: Apply a random user agent to each request
+- **Rotating proxy**: Use a pool of proxy that can be rotated. If a scrape request fail, the same request can be retried with proxies from the pool. 
 
-Note: The proxies are not being used at the moment, it can be considered as an improvement in the future
+Note: The proxy strategy is not currently used in the app, but it can be considered as an improvement in the future <br/>
+
+At the moment, application can handle only upto 10 keywords in 1 file
 
 #### Schema design
 

--- a/apps/api/.example.env
+++ b/apps/api/.example.env
@@ -1,2 +1,4 @@
 DATABASE_URL=""
 CORS_WHITELIST="http://example1.com,http://example2.com"
+FILE_UPLOAD_MAX_KEYWORD_LIMIT=100
+FILE_UPLOAD_MAX_SIZE=1024 #in bytes

--- a/apps/api/src/configs.ts
+++ b/apps/api/src/configs.ts
@@ -7,4 +7,10 @@ export const configs = {
   CORS_WHITELIST: process.env.CORS_WHITELIST
     ? process.env.CORS_WHITELIST.split(",")
     : [],
+  FILE_UPLOAD_MAX_KEYWORD_LIMIT: process.env.FILE_UPLOAD_MAX_KEYWORD_LIMIT
+    ? Number(process.env.FILE_UPLOAD_MAX_KEYWORD_LIMIT)
+    : 100,
+  FILE_UPLOAD_MAX_SIZE: process.env.FILE_UPLOAD_MAX_SIZE
+    ? Number(process.env.FILE_UPLOAD_MAX_SIZE)
+    : 1024,
 };

--- a/apps/api/src/routes/uploads/handlers/create-upload.handler.ts
+++ b/apps/api/src/routes/uploads/handlers/create-upload.handler.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 
 import { uploadRepository } from "../repositories";
 import { scraper, resultProcessor } from "../helpers";
-import { configs } from "../../../configs";
+import { configs } from "configs";
 
 export async function createNewUploadHandler(
   req: Request,

--- a/apps/api/src/routes/uploads/handlers/create-upload.handler.ts
+++ b/apps/api/src/routes/uploads/handlers/create-upload.handler.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from "express";
 
 import { uploadRepository } from "../repositories";
 import { scraper, resultProcessor } from "../helpers";
+import { configs } from "../../../configs";
 
 export async function createNewUploadHandler(
   req: Request,
@@ -21,6 +22,16 @@ export async function createNewUploadHandler(
   }
 
   const keywords = file.buffer.toString().split("\n") || [];
+  const limit = configs.FILE_UPLOAD_MAX_KEYWORD_LIMIT;
+
+  if (keywords.length > limit) {
+    res.status(400).json({
+      ok: false,
+      message: `file must be less than ${limit} keywords`,
+    });
+
+    return;
+  }
 
   try {
     const keywordsWithAgents = scraper.prepareAgents(keywords);

--- a/apps/api/src/routes/uploads/middlewares/upload.middleware.ts
+++ b/apps/api/src/routes/uploads/middlewares/upload.middleware.ts
@@ -7,6 +7,7 @@ import multer, {
 import { type Request } from "express";
 
 import { FileTypeNotSupportedError } from "errors";
+import { configs } from "configs";
 
 function csvFilter(
   _req: Request,
@@ -23,7 +24,7 @@ function csvFilter(
 const storage = memoryStorage();
 
 const limits = {
-  fileSize: 1024, //1 KB
+  fileSize: configs.FILE_UPLOAD_MAX_SIZE,
 };
 
 const options: Options = {


### PR DESCRIPTION
#### What does this PR do?

This PR is to add the missing validation for the number of keywords in a file
Close #29 

#### How is it implemented

- Add new environment variables for file-related limits. Updated README and `.example.env` file
- Update handler to check for the number of keywords and reject request if limit exceeded

#### Screenshots

<img width="1512" alt="Screenshot 2023-10-06 at 22 19 21" src="https://github.com/nhantran3395/scrapper/assets/50472067/c2e1cbd4-4403-4d43-9538-0c1476c0b024">
